### PR TITLE
feat(HGI-9277): add a new method to sanitize table names

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ jsonschema~=2.6.0
 setuptools~=60.3.1
 pendulum
 backoff==1.8.0
+regex==2024.4.16

--- a/target_bigquery/processhandler.py
+++ b/target_bigquery/processhandler.py
@@ -15,7 +15,8 @@ from google.cloud.exceptions import NotFound
 from jsonschema.validators import validator_for
 
 from target_bigquery.encoders import DecimalEncoder
-from target_bigquery.schema import build_schema, cleanup_record, create_valid_bigquery_name, format_record_to_schema
+from target_bigquery.schema import build_schema, cleanup_record, create_valid_bigquery_name, \
+    format_record_to_schema, create_valid_bigquery_table_name
 
 from target_bigquery.simplify_json_schema import simplify
 from target_bigquery.validate_json_schema import validate_json_schema_completeness, \
@@ -86,9 +87,16 @@ class BaseProcessHandler(object):
                 self.table_prefix, msg.stream, self.table_suffix
             )
         
-        self.tables[msg.stream] = create_valid_bigquery_name(
-            self.tables[msg.stream]
-        ) if self.force_alphanumeric_table_names else self.tables[msg.stream]
+        # first perform the safe sanitization, only replace the invalid characters
+        # that would make the target fail
+        self.tables[msg.stream] = create_valid_bigquery_table_name(self.tables[msg.stream])
+
+        # if `force_alphanumeric_table_names` perform the more strict sanitization
+        # we kept this to keep the backward compatibility with the previous behavior
+        if self.force_alphanumeric_table_names:
+            self.tables[msg.stream] = create_valid_bigquery_name(
+                self.tables[msg.stream]
+            )
 
         self.schemas[msg.stream] = msg.schema
         validator_cls = validator_for(msg.schema)

--- a/target_bigquery/processhandler.py
+++ b/target_bigquery/processhandler.py
@@ -288,7 +288,10 @@ class LoadJobProcessHandler(BaseProcessHandler):
         loaded_tmp_tables = []
         try:
             for stream in rows.keys():
-                tmp_table_name = "t_{}_{}".format(self.tables[stream], str(uuid.uuid4()).replace("-", ""))
+                # truncate the table name to 989 characters because BQ has table name
+                # limit of 1024 characters.
+                # So it's 989 + 3 (for the prefix) + 32 (for the random uuid) = 1024 max characters.
+                tmp_table_name = "t_{}_{}".format(self.tables[stream][:989], str(uuid.uuid4()).replace("-", ""))
 
                 job = self._load_to_bq(
                     client=self.client,

--- a/target_bigquery/schema.py
+++ b/target_bigquery/schema.py
@@ -2,6 +2,7 @@
 the purpose of this module is to convert JSON schema to BigQuery schema.
 """
 import re
+import regex
 
 from target_bigquery.simplify_json_schema import BQ_DECIMAL_SCALE_MAX, BQ_BIGDECIMAL_SCALE_MAX, \
     BQ_DECIMAL_MAX_PRECISION_INCREMENT, BQ_BIGDECIMAL_MAX_PRECISION_INCREMENT
@@ -101,10 +102,12 @@ def create_valid_bigquery_table_name(table_name: str) -> str:
         str: A sanitized, BigQuery-compliant table name.
     """
     # negative regex pattern of the allowed BQ Table Name characters
-    regex_pattern = r"[^LMNPcPdZs\w\s-]"
+    regex_pattern = r"[^\p{L}\p{M}\p{N}\p{Pc}\p{Pd}\p{Zs}\w\s-]"
 
     # replace invalid characters with an underscore
-    table_name = re.sub(regex_pattern, "_", table_name)
+    # uses the `regex` lib because the standard `re` lib
+    # does not support Unicode characters categories
+    table_name = regex.sub(regex_pattern, "_", table_name)
 
     # Truncate to 300 characters if necessary
     table_name = table_name[:1024]

--- a/target_bigquery/schema.py
+++ b/target_bigquery/schema.py
@@ -109,7 +109,7 @@ def create_valid_bigquery_table_name(table_name: str) -> str:
     # does not support Unicode characters categories
     table_name = regex.sub(regex_pattern, "_", table_name)
 
-    # Truncate to 300 characters if necessary
+    # Truncate to 1024 characters if necessary
     table_name = table_name[:1024]
 
     return table_name

--- a/target_bigquery/schema.py
+++ b/target_bigquery/schema.py
@@ -83,6 +83,35 @@ def create_valid_bigquery_name(column_name: str) -> str:
     return column_name
 
 
+def create_valid_bigquery_table_name(table_name: str) -> str:
+    """
+    Transforms a given table name into a BigQuery-compliant table name.
+
+    BigQuery table naming rules:
+    - https://docs.cloud.google.com/bigquery/docs/tables#table_naming
+    - Contain characters with a total of up to 1,024 UTF-8 bytes.
+    - Contain Unicode characters in category L (letter), M (mark), N (number),
+        Pc (connector, including underscore), Pd (dash), Zs (space).
+    - Any characters that are not in the list above will be replaced with an underscore.
+
+    Args:
+        table_name (str): The original table name.
+
+    Returns:
+        str: A sanitized, BigQuery-compliant table name.
+    """
+    # negative regex pattern of the allowed BQ Table Name characters
+    regex_pattern = r"[^LMNPcPdZs\w\s-]"
+
+    # replace invalid characters with an underscore
+    table_name = re.sub(regex_pattern, "_", table_name)
+
+    # Truncate to 300 characters if necessary
+    table_name = table_name[:1024]
+
+    return table_name
+
+
 def prioritize_one_data_type_from_multiple_ones_in_any_of(field_property):
     """
     :param field_property: JSON field property, which has anyOf and multiple data types


### PR DESCRIPTION
- Adds a new method to sanitize table names, the old one uses the validation that is used for columns names (which is way more strict).
- The new method only replaces invalid characters with _underscore_ (replaces only the characters not allowed in BQ table names).
- The new sanitization method is always used.
- The old one is used on top of the new one if the config flag is on (`force_alphanumeric_table_names`)