### PR TITLE
feat(HGI-9350): implement new table name sanitization method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 .idea/*
 .pytest_cache/*
 .spyproject/*
+.venv/
 venv/*
 __pycache__
 target_bigquery.egg-info

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ backoff==1.8.0
 pydantic==2.11.9
 pyarrow==21.0.0
 fastjsonschema==2.21.2
+regex==2024.4.16

--- a/target_bigquery/bigquery_schema.py
+++ b/target_bigquery/bigquery_schema.py
@@ -3,6 +3,7 @@ the purpose of this module is to convert JSON schema to BigQuery schema.
 """
 
 import re
+import regex
 from functools import lru_cache
 
 from target_bigquery.simplify_json_schema import (
@@ -73,6 +74,34 @@ def create_valid_bigquery_name(column_name: str) -> str:
             column_name = "_" + column_name
 
     return column_name
+
+
+def create_valid_bigquery_table_name(table_name: str) -> str:
+    """
+    Transforms a given table name into a BigQuery-compliant table name.
+    BigQuery table naming rules:
+    - https://docs.cloud.google.com/bigquery/docs/tables#table_naming
+    - Contain characters with a total of up to 1,024 UTF-8 bytes.
+    - Contain Unicode characters in category L (letter), M (mark), N (number),
+        Pc (connector, including underscore), Pd (dash), Zs (space).
+    - Any characters that are not in the list above will be replaced with an underscore.
+    Args:
+        table_name (str): The original table name.
+    Returns:
+        str: A sanitized, BigQuery-compliant table name.
+    """
+    # negative regex pattern of the allowed BQ Table Name characters
+    regex_pattern = r"[^\p{L}\p{M}\p{N}\p{Pc}\p{Pd}\p{Zs}\w\s-]"
+
+    # replace invalid characters with an underscore
+    # uses the `regex` lib because the standard `re` lib
+    # does not support Unicode characters categories
+    table_name = regex.sub(regex_pattern, "_", table_name)
+
+    # Truncate to 1024 characters if necessary
+    table_name = table_name[:1024]
+
+    return table_name
 
 
 def prioritize_one_data_type_from_multiple_ones_in_any_of(field_property):

--- a/target_bigquery/biquery_loader.py
+++ b/target_bigquery/biquery_loader.py
@@ -99,7 +99,7 @@ class BigQueryLoader:
             )
 
             # Upload to GCS with optional key prefix
-            blob_name = f"{self.process_result.table_names[stream_name]}.parquet"
+            blob_name = f"{os.path.basename(self.process_result.parquet_files[stream_name])}"
             if self.target_config.gcs_key_prefix:
                 # Ensure prefix doesn't start with / and ends properly
                 prefix = self.target_config.gcs_key_prefix.strip("/")

--- a/target_bigquery/process.py
+++ b/target_bigquery/process.py
@@ -13,6 +13,7 @@ from target_bigquery.config import TargetConfig, TablesConfig, TableConfig
 from target_bigquery.bigquery_schema import (
     build_schema,
     create_valid_bigquery_name,
+    create_valid_bigquery_table_name,
 )
 from target_bigquery.pyarrow_schema import (
     convert_and_filter_record_to_pyarrow,
@@ -317,6 +318,7 @@ class SingerProcessor:
         self, stream_name: str, prefix: str, suffix: str, force_alphanumeric_table_names: bool
     ):
         table_name = "{}{}{}".format(prefix, stream_name, suffix)
+        table_name = create_valid_bigquery_table_name(table_name)
         if force_alphanumeric_table_names:
             return create_valid_bigquery_name(table_name)
         else:

--- a/target_bigquery/process.py
+++ b/target_bigquery/process.py
@@ -5,6 +5,7 @@ import io
 import singer
 import pyarrow as pa
 import pyarrow.parquet as pq
+from hashlib import sha256
 from typing import Any, Dict, List, Union
 from target_bigquery.state import State, LiteralState
 from datetime import datetime
@@ -361,7 +362,8 @@ class SingerProcessor:
         """
         if stream_name not in self.parquet_writers:
             # Create parquet file path
-            parquet_file = f"{stream_name}.parquet"
+            file_name_hash = sha256(stream_name.encode('utf-8')).hexdigest()
+            parquet_file = f"{file_name_hash}.parquet"
             parquet_file_path = os.path.abspath(parquet_file)
             self.parquet_files[stream_name] = parquet_file_path
 


### PR DESCRIPTION
- Adds a new method to sanitize table names, the old one uses the validation that is used for columns names (which is way more strict).
- The new method only replaces invalid characters with underscore (replaces only the characters not allowed in BQ table names).
- The new sanitization method is always used.
- The old one is used on top of the new one if the config flag is on (`force_alphanumeric_table_names`)
- Hash stream name to use as the parquet file name to avoid long names issues